### PR TITLE
Bugsnag expects notifyError not notify()

### DIFF
--- a/src/BugsnagHandler.php
+++ b/src/BugsnagHandler.php
@@ -50,7 +50,8 @@ class BugsnagHandler extends AbstractProcessingHandler
                 $severity
             );
         } else {
-            $this->client->notify(
+            $this->client->notifyError(
+                $severity,
                 (string) $record['message'],
                 $record,
                 $severity

--- a/tests/unit-tests/BugsnagHandlerTest.php
+++ b/tests/unit-tests/BugsnagHandlerTest.php
@@ -34,14 +34,14 @@ class BugsnagHandlerTest extends ProphecyTestCase
     public function testHandlerDefaultsToErrorOnly()
     {
         $this->mockBugsnag->notifyException(Argument::any(), Argument::cetera())->shouldNotBeCalled();
-        $this->mockBugsnag->notify(Argument::any(), Argument::cetera())->shouldNotBeCalled();
+        $this->mockBugsnag->notifyError(Argument::any(), Argument::cetera())->shouldNotBeCalled();
         $this->monolog->addInfo("Hello World");
     }
 
     public function testNotifyIsCalledOnErrors()
     {
         $errorMessage = "Oh no!";
-        $this->mockBugsnag->notify($errorMessage, Argument::cetera())->shouldBeCalledTimes(1);
+        $this->mockBugsnag->notifyError(Argument::any(), $errorMessage, Argument::cetera())->shouldBeCalledTimes(1);
         $this->monolog->addError($errorMessage);
     }
 
@@ -65,7 +65,7 @@ class BugsnagHandlerTest extends ProphecyTestCase
         $this->monolog->pushHandler($this->testedHandler);
 
         $errorMessage = "Oh no!";
-        $this->mockBugsnag->notify(Argument::any(), Argument::any(), $expectedSeverity)->shouldBeCalledTimes(1);
+        $this->mockBugsnag->notifyError($expectedSeverity, Argument::any(), Argument::any(), $expectedSeverity)->shouldBeCalledTimes(1);
         $this->monolog->log($monologLevel, $errorMessage);
     }
 


### PR DESCRIPTION
The notify() function requires a Bugsnag_Error object.

The current Bugsnag client library dies when you send a string to $client->notify() since it expects a Bugsnag_Error object. The correct function to call is notifyError().

This uses severity for the name of the error because I'm not sure what to use for that.
