### PR TITLE
Update severityMapping

### DIFF
--- a/src/BugsnagHandler.php
+++ b/src/BugsnagHandler.php
@@ -18,8 +18,8 @@ class BugsnagHandler extends AbstractProcessingHandler
         Logger::WARNING   => 'warning',
         Logger::ERROR     => 'error',
         Logger::CRITICAL  => 'error',
-        Logger::ALERT     => 'fatal',
-        Logger::EMERGENCY => 'fatal'
+        Logger::ALERT     => 'error',
+        Logger::EMERGENCY => 'error'
     );
 
     /**

--- a/tests/unit-tests/BugsnagHandlerTest.php
+++ b/tests/unit-tests/BugsnagHandlerTest.php
@@ -78,8 +78,8 @@ class BugsnagHandlerTest extends ProphecyTestCase
             array(Logger::WARNING,   "warning"),
             array(Logger::ERROR,     "error"),
             array(Logger::CRITICAL,  "error"),
-            array(Logger::ALERT,     "fatal"),
-            array(Logger::EMERGENCY, "fatal")
+            array(Logger::ALERT,     "error"),
+            array(Logger::EMERGENCY, "error")
         );
     }
 }


### PR DESCRIPTION
The latest bugsnag client only allows error, warning and info. See https://github.com/bugsnag/bugsnag-php/blob/master/src/Bugsnag/Error.php#L5-L9

Trying to set "fatal" results in
```
Bugsnag Warning: Tried to set error severity to fatal which is not allowed.
```